### PR TITLE
Added binary location tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ As of right now, Clanki can only be installed through cabal, which is part of th
     cabal update
     cabal install clanki
 
+The clanki executable should now be available in `$HOME/.cabal/bin/`.
 
 ##Command-line options
 


### PR DESCRIPTION
Most people (like me) might expect that the binary becomes available in $PATH, and wonder why `clanki` returns `command not found`.
